### PR TITLE
Restored ParseClientCommand, CMD_STRING, and Soft_Restart to Quakespasm

### DIFF
--- a/source/keys.c
+++ b/source/keys.c
@@ -263,6 +263,7 @@ char *osk_text2 [] =
 	"     Z X C V B N M   < > ? "
 };
 extern qboolean console_enabled;
+extern char *pr_strings;
 void Key_Console (int key)
 {
 	static	char current[MAXCMDLINE] = "";
@@ -351,6 +352,13 @@ void Key_Console (int key)
 			key_linepos = 1;
 			if (cls.state == ca_disconnected)
 				SCR_UpdateScreen (); // force an update, because the command may take some time
+			
+			// for clientside cmds							
+			if (cls.state == ca_connected)
+			{
+				pr_global_struct->CMD_STRING = (key_lines[edit_line-1]+1 - pr_strings);
+				PR_ExecuteProgram (pr_global_struct->ParseClientCommand);
+			}
 			return;
 		case K_TAB:
 		case K_LSHOULDER:

--- a/source/menu.c
+++ b/source/menu.c
@@ -686,7 +686,8 @@ void M_Restart_Key (int key)
 		key_dest = key_game;
 		m_state = m_none;
 		paused_hack = false;
-		Cbuf_AddText ("restart\n");
+		//Cbuf_AddText ("restart\n");
+		PR_ExecuteProgram (pr_global_struct->Soft_Restart);
 		break;
 	default:
 		break;

--- a/source/progdefs.q1
+++ b/source/progdefs.q1
@@ -56,6 +56,9 @@ typedef struct
 	func_t		ClientDisconnect;
 	func_t		SetNewParms;
 	func_t		SetChangeParms;
+	func_t      ParseClientCommand;					// special command calls
+	string_t    CMD_STRING;
+	func_t      Soft_Restart;
 } globalvars_t;
 
 typedef struct


### PR DESCRIPTION
and initialized features in engine