### PR TITLE
NX: Downgrade GCC 14 errors to warnings

### DIFF
--- a/Makefile.nx
+++ b/Makefile.nx
@@ -130,7 +130,7 @@ EXEFS_SRC	:=	exefs_src
 #---------------------------------------------------------------------------------
 ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE -mcpu=cortex-a57+crc+fp+simd
 
-CFLAGS	:=	-g -Wall -O3 -fno-strict-aliasing -fomit-frame-pointer -ffunction-sections \
+CFLAGS	:=	-g -fpermissive -Wall -O3 -fno-strict-aliasing -fomit-frame-pointer -ffunction-sections \
 			$(ARCH) $(DEFINES)
 
 CFLAGS	+=	$(INCLUDE) -D__SWITCH__


### PR DESCRIPTION
https://gcc.gnu.org/gcc-14/porting_to.html#warnings-as-errors

GCC 14 upgraded certain warnings about non-standard C features to errors. -fpermissive is the documented way to turn them back to warnings and allow the build to succeed.

For our long term sanity, it would be better to resolve the warnings properly, but this will do for now.